### PR TITLE
holiday_jpのバージョンにおける振替休日の表記の差と各実装の状況の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Japanese holiday datasets
 
+## holiday_jp Versions
+
+| Versions | 振替休日の表記 |
+| --- | --- |
+| v0.x | `振替休日` |
+| v1.x | `勤労感謝の日 振替休日` |
+
+## Implemantations
+
+| Implemantations | Release version using holiday_jp v0.x | Release version using holiday_jp v1.x |
+| --- | --- |
+| [Ruby](https://github.com/holiday-jp/holiday_jp-ruby) | - | - |
+| [JavaScript](https://github.com/holiday-jp/holiday_jp-js) | v1.x | v2.x |
+| [PHP](https://github.com/holiday-jp/holiday_jp-php) | v1.x | v2.x |
+| [Java](https://github.com/holiday-jp/holiday_jp-java) | - | v0.1.x |
+| [Swift](https://github.com/holiday-jp/holiday_jp-swift) | v0.1.x | v0.2.x |
+| [Go](https://github.com/holiday-jp/holiday_jp-go) | - | master |
+
 ## "Datasets" idea
 
 [Project Woothee](https://woothee.github.io/)
@@ -15,6 +33,3 @@ syukujitsu.csv
 ## Test by Google Calendar API
 
 https://calendar.google.com/calendar/embed?src=ja.japanese%23holiday@group.v.calendar.google.com
-
-
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Japanese holiday datasets
 
 | Implemantation | Release version using holiday_jp v0.x | Release version using holiday_jp v1.x |
 | --- | --- | --- |
-| [Ruby](https://github.com/holiday-jp/holiday_jp-ruby) | - | - |
+| [Ruby](https://github.com/holiday-jp/holiday_jp-ruby) | v0.7.x | - |
 | [JavaScript](https://github.com/holiday-jp/holiday_jp-js) | v1.x | v2.x |
 | [PHP](https://github.com/holiday-jp/holiday_jp-php) | v1.x | v2.x |
 | [Java](https://github.com/holiday-jp/holiday_jp-java) | - | v0.1.x |

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Japanese holiday datasets
 
 ## holiday_jp Versions
 
-| Versions | 振替休日の表記 |
+| Version | 振替休日の表記 |
 | --- | --- |
 | v0.x | `振替休日` |
 | v1.x | `勤労感謝の日 振替休日` |
 
 ## Implemantations
 
-| Implemantations | Release version using holiday_jp v0.x | Release version using holiday_jp v1.x |
-| --- | --- |
+| Implemantation | Release version using holiday_jp v0.x | Release version using holiday_jp v1.x |
+| --- | --- | --- |
 | [Ruby](https://github.com/holiday-jp/holiday_jp-ruby) | - | - |
 | [JavaScript](https://github.com/holiday-jp/holiday_jp-js) | v1.x | v2.x |
 | [PHP](https://github.com/holiday-jp/holiday_jp-php) | v1.x | v2.x |


### PR DESCRIPTION
Fix #77 

@komagata 
holiday-jp/holiday_jpと（テストで）連携する holiday-jp/holiday_jp-ruby の次のバージョンがリリースされたらマージしようと思っています。