### PR TITLE
Fix: Add permitted_classes: [Date] to Yaml.load_file

### DIFF
--- a/spec/holidays_detailed_spec.rb
+++ b/spec/holidays_detailed_spec.rb
@@ -6,7 +6,7 @@ require 'date'
 
 context 'Emperor\'s Birthday' do
   before do
-    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__))
+    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__), permitted_classes: [Date])
   end
 
   it 'holidays_detail.yml should have holiday in Showa Emperor\'s Birthday' do
@@ -35,7 +35,7 @@ end
 
 context 'Holiday in lieu' do
   before do
-    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__))
+    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__), permitted_classes: [Date])
   end
 
   it 'If holiday is Sunday, Holiday in lieu should exist. (>= 1973.4.30)' do
@@ -49,7 +49,7 @@ end
 
 context 'Tokyo Olympic' do
   before do
-    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__))
+    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__), permitted_classes: [Date])
   end
 
   it 'If tokyo olympic year, 海の日 should be moved' do
@@ -86,7 +86,7 @@ end
 
 context 'Coronation Day / 天皇の即位の日及び即位礼正殿の儀の行われる日を休日とする法律' do
   before do
-    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__))
+    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__), permitted_classes: [Date])
   end
   it '天皇の即位の日の平成31年（2019年）5月1日及び即位礼正殿の儀が行われる日の平成31年（2019年）10月22日は、休日となります' do
     expect(@holidays_detailed.key?(Date::parse('2019-05-01'))).to eq true
@@ -100,11 +100,11 @@ end
 
 context 'holiday.yml' do
   before do
-    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__))
+    @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__), permitted_classes: [Date])
   end
 
   it 'holidays_detailed.yml should have date of holiday.yml and holiday.yml should have of holiday_detail.yml' do
-    holidays = YAML.load_file(File.expand_path('../../holidays.yml', __FILE__))
+    holidays = YAML.load_file(File.expand_path('../../holidays.yml', __FILE__), permitted_classes: [Date])
     holidays.each do |date, name|
       expect(@holidays_detailed.key?(date)).to eq true
       expect(@holidays_detailed[date]['name']).to eq name

--- a/spec/syukujitsu_csv_spec.rb
+++ b/spec/syukujitsu_csv_spec.rb
@@ -8,7 +8,7 @@ require 'uri'
 
 context 'Check holidays.yml by syukujitsu.csv' do
   before do
-    @holidays = YAML.load_file(File.expand_path('../../holidays.yml', __FILE__))
+    @holidays = YAML.load_file(File.expand_path('../../holidays.yml', __FILE__), permitted_classes: [Date])
     csv_url = 'https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv'
     csv = URI.open(csv_url).read
     @cholidays = CSV.parse(csv, headers: true, encoding: 'Shift_JIS')


### PR DESCRIPTION
Above ruby 3.1,  Yaml.load does not allow to load date object in yaml file.
This ruby changes breaks tests

ref:
[Ruby 3.1 で非互換になる YAML.load](https://www.docswell.com/s/pink_bangbi/K67RV5-2022-01-06-201330#p14https://www.docswell.com/s/pink_bangbi/K67RV5-2022-01-06-201330#p14)
[Ruby 3.1’s incompatible changes to its YAML module (Psych 4)](https://www.ctrl.blog/entry/ruby-psych4.html#:~:text=Here%E2%80%98s%20the%20default,Hash)

```
kyama@Nyanko-Book-Pro holiday_jp % bundle exec rspec  
FFFFFFFFFFFFFFFFFF

Failures:

  1) Emperor's Birthday holidays_detail.yml should have holiday in Showa Emperor's Birthday
     Failure/Error: @holidays_detailed = YAML.load_file(File.expand_path('../../holidays_detailed.yml', __FILE__))
     
     Psych::DisallowedClass:
       Tried to load unspecified class: Date
     # (eval):2:in `date'
     # ./spec/holidays_detailed_spec.rb:9:in `block (2 levels) in <top (required)>'

...

and other test cases fails like above case

```



To fix this, I pass permitted_classes to Yaml.load_file. [ruby document for psych](https://docs.ruby-lang.org/ja/latest/class/Psych.html#S_LOAD_FILE)


After changes applied
```
kyama@Nyanko-Book-Pro holiday_jp % bundle exec rspec
..................

Finished in 1.23 seconds (files took 0.21654 seconds to load)
18 examples, 0 failures
```

All test passes.


NOTE:
Should we consider use Psych instead of Yaml?